### PR TITLE
remove user_panels from download_data call

### DIFF
--- a/lib/Gene2phenotype.pm
+++ b/lib/Gene2phenotype.pm
@@ -263,7 +263,6 @@ sub startup {
     my $ip = $c->remote_addr;
     my $file_name = $c->stash('file_name');
     my $is_logged_in = $c->session('logged_in');
-    my $user_panels = $c->session('panels');
     my $panel_name = $file_name;
     $panel_name =~ s/G2P\.csv\.gz//;
     $file_name =~ s/\.csv\.gz//;
@@ -276,7 +275,7 @@ sub startup {
     my $tmp_dir = "$downloads_dir/$stamp";
     mkpath($tmp_dir);
     $log->debug("download file $ip $panel_name $year $mon $mday");
-    download_data($tmp_dir, $file_name, $registry_file, $is_logged_in, $user_panels, $panel_name);
+    download_data($tmp_dir, $file_name, $registry_file, $is_logged_in, $panel_name);
     $c->render_file('filepath' => "$tmp_dir/$file_name.gz", 'filename' => "$file_name.gz", 'format' => 'zip', 'cleanup' => 1);
   });
 

--- a/lib/Gene2phenotype.pm
+++ b/lib/Gene2phenotype.pm
@@ -263,9 +263,21 @@ sub startup {
     my $ip = $c->remote_addr;
     my $file_name = $c->stash('file_name');
     my $is_logged_in = $c->session('logged_in');
+    my @authorised_panels = @{$c->stash('authorised_panels')};
     my $panel_name = $file_name;
     $panel_name =~ s/G2P\.csv\.gz//;
     $file_name =~ s/\.csv\.gz//;
+
+    # Can the user download data for the specified panel?
+    # If the user is not logged check if the panel that the user
+    # wants to download is in the list of authorised panels (visible panels)
+    if (!$is_logged_in) {
+      if (! grep {$panel_name eq $_} @authorised_panels) {
+        $c->flash(message => 'Specified panel cannot be downloaded. Please contact g2p-help@ebi.ac.uk', alert_class => 'alert-danger');
+        return $c->redirect_to('/gene2phenotype/downloads');
+      }          
+    }   
+
     my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = localtime(time);
     $year += 1900;
     $mon++;


### PR DESCRIPTION
user panel information is not needed for downloading data. (https://github.com/EBI-G2P/ensembl-gene2phenotype/pull/34)