### PR TITLE
Various fixes to DECIPHER URLs

### DIFF
--- a/templates/gene.html.ep
+++ b/templates/gene.html.ep
@@ -31,12 +31,12 @@
         <% my $link = "https://www.ncbi.nlm.nih.gov/clinvar/?term=" . $gene->{gene_symbol} . "%5Bgene%5D"; %>
         <%= link_to $link => (target => '_blank') => begin %>ClinVar<% end %>
         <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#variants/" . $gene->{gene_symbol} . "/patient-overlap/snvs"; %>
-        <%= link_to $link => (target => '_blank') => begin %>Decipher<% end %>
+        <%= link_to $link => (target => '_blank') => begin %>DECIPHER<% end %>
       </dd>
       <dt>Protein information</dt>
       <dd>
         <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#overview/protein-info"; %>
-        <%= link_to $link => (target => '_blank') => begin %>Decipher<% end %>
+        <%= link_to $link => (target => '_blank') => begin %>DECIPHER<% end %>
       </dd>
     </dl>
   </div>

--- a/templates/gene.html.ep
+++ b/templates/gene.html.ep
@@ -30,12 +30,12 @@
       <dd>
         <% my $link = "https://www.ncbi.nlm.nih.gov/clinvar/?term=" . $gene->{gene_symbol} . "%5Bgene%5D"; %>
         <%= link_to $link => (target => '_blank') => begin %>ClinVar<% end %>
-        <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/patient-overlap"; %>
+        <% $link = "https://www.deciphergenomics.org/gene/" . $gene->{gene_symbol} . "/patient-overlap"; %>
         <%= link_to $link => (target => '_blank') => begin %>DECIPHER<% end %>
       </dd>
       <dt>Protein information</dt>
       <dd>
-        <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/overview/protein-genomic-info"; %>
+        <% $link = "https://www.deciphergenomics.org/gene/" . $gene->{gene_symbol} . "/overview/protein-genomic-info"; %>
         <%= link_to $link => (target => '_blank') => begin %>DECIPHER<% end %>
       </dd>
     </dl>

--- a/templates/gene.html.ep
+++ b/templates/gene.html.ep
@@ -30,12 +30,12 @@
       <dd>
         <% my $link = "https://www.ncbi.nlm.nih.gov/clinvar/?term=" . $gene->{gene_symbol} . "%5Bgene%5D"; %>
         <%= link_to $link => (target => '_blank') => begin %>ClinVar<% end %>
-        <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#variants/" . $gene->{gene_symbol} . "/patient-overlap/snvs"; %>
+        <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/patient-overlap"; %>
         <%= link_to $link => (target => '_blank') => begin %>DECIPHER<% end %>
       </dd>
       <dt>Protein information</dt>
       <dd>
-        <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#overview/protein-info"; %>
+        <% $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/overview/protein-genomic-info"; %>
         <%= link_to $link => (target => '_blank') => begin %>DECIPHER<% end %>
       </dd>
     </dl>

--- a/templates/phenotype.html.ep
+++ b/templates/phenotype.html.ep
@@ -1,7 +1,7 @@
 <div>
   <h3>Phenotypes</h3>
   <p>
-    <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#phenotypes"; %>
+    <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/phenotypes"; %>
     <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in DECIPHER <% end %>
   </p>
 

--- a/templates/phenotype.html.ep
+++ b/templates/phenotype.html.ep
@@ -2,7 +2,7 @@
   <h3>Phenotypes</h3>
   <p>
     <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#phenotypes"; %>
-    <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in Decipher <% end %>
+    <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in DECIPHER <% end %>
   </p>
 
   <% if (scalar @{$gfd->{phenotypes}} > 0) { %>

--- a/templates/phenotype.html.ep
+++ b/templates/phenotype.html.ep
@@ -1,7 +1,7 @@
 <div>
   <h3>Phenotypes</h3>
   <p>
-    <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/phenotypes"; %>
+    <% my $link = "https://www.deciphergenomics.org/gene/" . $gene->{gene_symbol} . "/phenotypes"; %>
     <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in DECIPHER <% end %>
   </p>
 

--- a/templates/user/phenotype.html.ep
+++ b/templates/user/phenotype.html.ep
@@ -24,7 +24,7 @@
       </div>
 
       <p>
-        <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/phenotypes"; %>
+        <% my $link = "https://www.deciphergenomics.org/gene/" . $gene->{gene_symbol} . "/phenotypes"; %>
         <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in DECIPHER <% end %>
       </p>
     

--- a/templates/user/phenotype.html.ep
+++ b/templates/user/phenotype.html.ep
@@ -25,7 +25,7 @@
 
       <p>
         <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#phenotypes"; %>
-        <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in Decipher <% end %>
+        <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in DECIPHER <% end %>
       </p>
     
       <% if (scalar @{$gfd->{phenotypes}} > 0) { %>

--- a/templates/user/phenotype.html.ep
+++ b/templates/user/phenotype.html.ep
@@ -24,7 +24,7 @@
       </div>
 
       <p>
-        <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "#phenotypes"; %>
+        <% my $link = "https://decipher.sanger.ac.uk/gene/" . $gene->{gene_symbol} . "/phenotypes"; %>
         <%= link_to $link => (target => '_blank') => begin %>Look up phenotypes associated with <%= $gfd->{gene_symbol} %> in DECIPHER <% end %>
       </p>
     


### PR DESCRIPTION
I spotted that G2P links to some DECIPHER gene page URLs which have changed since G2P started using them. They currently go to the gene page root rather than the tabs they were written to link to.

NB: I've written this PR by eye as I've not got a development environment for G2P set up, so please do just confirm the proposed links work.