### PR TITLE
Fix method to update disease

### DIFF
--- a/lib/Gene2phenotype/Model/GenomicFeatureDisease.pm
+++ b/lib/Gene2phenotype/Model/GenomicFeatureDisease.pm
@@ -809,8 +809,9 @@ sub update_disease {
   my $registry = $self->app->defaults('registry');
   my $disease_adaptor =  $registry->get_adaptor('human', 'gene2phenotype', 'Disease');
   my $disease = $disease_adaptor->fetch_by_dbID($disease_id);
-  if ($disease->name ne $disease_name || ($disease->mim && $disease->mim ne $disease_mim)) {
 
+  if ($disease->name ne $disease_name || ($disease->mim && $disease->mim ne $disease_mim)
+      || (!$disease->mim && $disease_mim)) {
     my $GFD_adaptor = $registry->get_adaptor('human', 'gene2phenotype', 'GenomicFeatureDisease');
     my $user_adaptor = $registry->get_adaptor('human', 'gene2phenotype', 'user');
     my $user = $user_adaptor->fetch_by_email($email);


### PR DESCRIPTION
The option `Edit Disease Attributes` does not work when we try to add a omim id to a disease without omim id.
