### PR TITLE
Fix code to update mutation consequence

### DIFF
--- a/lib/Gene2phenotype/Controller/GenomicFeatureDisease.pm
+++ b/lib/Gene2phenotype/Controller/GenomicFeatureDisease.pm
@@ -337,7 +337,6 @@ sub update_mutation_consequence_temp {
 
   $self->stash(gfd => $gfd);
 
-
   my $mutation_consequences =  $gfd_model->get_mutation_consequences;
   $self->stash(mutation_consequences => $mutation_consequences);
   
@@ -366,19 +365,24 @@ sub update_mutation_consequence {
   my $gf_model = $self->model('genomic_feature');
   my $gene_symbol = $gfd->{gene_symbol};
   my $gf = $gf_model->fetch_by_gene_symbol($gene_symbol);
+
   if (!defined $mutation_consequence){
     my $mutation_consequence_attribs_id = join(',', sort@{$self->every_param('mutation_consequence_attrib_id')});
     $mutation_consequence = $gfd_model->get_value('mutation_consequence', $mutation_consequence_attribs_id);
   }
+
   my $email = $self->session('email');
   if ($mutation_consequence eq $gfd->{mutation_consequence}) {
     $self->feedback_message('SELECTED_MUTATION_CONSEQ');
     return $self->redirect_to("/gene2phenotype/gfd/show_attribs?GFD_id=$GFD_id");
   }
+
   my $gfds = $gfd_model->fetch_all_by_GenomicFeature_constraints($gf, {
     'mutation_consequence' => $mutation_consequence,
-    'allelic_requirement' => $gfd->{allelic_requirement},
+    'allelic_requirement'  => $gfd->{allelic_requirement},
+    'disease_id'           => $gfd->{disease_id}
   });
+
   if (scalar @$gfds == 0) {
     $gfd_model->update_mutation_consequence($email, $GFD_id, $mutation_consequence);
     $self->session(last_url => "/gene2phenotype/gfd/show_attribs?GFD_id=$GFD_id");
@@ -421,7 +425,6 @@ sub update_mutation_consequence_flag_temp {
   }
 
   $self->stash(gfd => $gfd);
-
 
   my $mutation_consequence_flags = $gfd_model->get_mutation_consequence_flags;
   $self->stash(mutation_consequence_flags => $mutation_consequence_flags);
@@ -482,8 +485,6 @@ sub update_variant_consequence_temp {
   my $gfd;
   my $authorised_panels = $self->stash('authorised_panels');
   my $logged_in = 0;
-
-
   my $gfd_model = $self->model('genomic_feature_disease');
   my $disease_model = $self->model('disease');
   if ($self->session('logged_in')) {
@@ -520,6 +521,7 @@ sub update_variant_consequence {
   my $logged_in = 1;
   my $authorized_panels = $self->stash('authorized_panels');
   $gfd = $model->fetch_by_dbID($GFD_id, $logged_in, $authorized_panels);
+
   if (!defined $variant_consequence) {
     my $variant_consequence_attrib_ids = join(',', sort@{$self->every_param('variant_consequence_attrib_id')});
     $variant_consequence = $model->get_value('variant_consequence', $variant_consequence_attrib_ids);

--- a/templates/show_attribs.html.ep
+++ b/templates/show_attribs.html.ep
@@ -33,8 +33,6 @@
       %end
    % }
   </div>
-  
-
 
   <div style="margin: 25px">
       <dt style="font-size:15px">Mutation consequence summary</dt>
@@ -47,7 +45,6 @@
      %end
   </div>
  
-
   <div style="margin: 25px" >
     % if ($gfd->{mutation_consequence_flag}) {
       <dt style=font-size:15px>Mutation consequence flag</dt> 
@@ -86,10 +83,12 @@
   %end
 % } 
 </div>
-  
- <div style="margin: 25px" >
-   %= form_for '/gene2phenotype/gfd' => begin
-     %= hidden_field GFD_id => $gfd->{GFD_id}
-     <input id="button" type="submit" value="BACK" class="btn btn-primary btn-sm" style="float: left;">
-   %end
- </div>
+
+%= include 'alerts'
+
+<div style="margin: 25px" >
+  %= form_for '/gene2phenotype/gfd' => begin
+    %= hidden_field GFD_id => $gfd->{GFD_id}
+    <input id="button" type="submit" value="BACK" class="btn btn-primary btn-sm" style="float: left;">
+  %end
+</div>

--- a/templates/user/gfd.html.ep
+++ b/templates/user/gfd.html.ep
@@ -4,6 +4,9 @@
 
   <h3 class="title">Gene: <span class="text-primary"><i><%= $gfd->{gene_symbol} %></i></span> Disease: <span class="text-primary"><i><% if (index(lc $gfd->{disease_name}, lc $gfd->{gene_symbol}) != -1) { %><%= $gfd->{disease_name} %><% } else { %><%= $gfd->{gene_symbol} %>-related <%= $gfd->{disease_name} %><% } %></i></span></h3>
   <div class="clear"></div>
+
+  %= include 'alerts'
+
   <div class="show_db_content">
     % my $found = 0;
      <% foreach my $gfd_panel (@{$gfd->{gfd_panels}}) { %>
@@ -35,7 +38,7 @@
         % }
       % }
     </dl>
-    
+
     <dl>
       <br>
         % if ( $gfd->{variant_consequence} ) {


### PR DESCRIPTION
Before the mutation consequence is updated there is a check to make sure the entry is not already in the db.
That check was only using:
- genomic feature
- allelic requirement
- mutation consequence

This PR adds the disease_id to the check as the disease is part of what defines an unique ID.
This PR also fixes the alert messages (they were not displayed).
